### PR TITLE
Updated documentation for reference to specify Python and pip paths.

### DIFF
--- a/INSTALL.adoc
+++ b/INSTALL.adoc
@@ -122,6 +122,16 @@ requiring C++ support.
 cmake -DWITH_CPP=ON -DWITH_FORTRAN=OFF /path/to/hermes-x.y.z
 ----
 
+=== Specifying Python Interpreter
+
+If your system has multiple Python interpreters you can directly specify paths
+to the desired interpreter and `pip` package manager to ensure they don't get mixed
+by CMake.
+
+----
+cmake -DPYTHON_EXECUTABLE:FILEPATH=/path/to/python -DPip_EXECUTABLE=/path/to/pip/or/pip2 /path/to/hermes-x.y.z
+----
+
 === Documentation
 
 By default, documentation will be built if the document generation toolchain


### PR DESCRIPTION
I had some trouble on Mac OS where CMake was finding the system Python interpreter in `/usr/bin`, but finding a `pip` from a Homebrew installation. This caused trouble when trying to build the "hermes-python" target.

This was remedied by directly providing paths to the executables. I figured it might be useful to add this to the documentation in the event someone else runs into this.